### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ do a `$ npm install --global phantomjs`
 
 ---
 
-##Config
+## Config
 All config must be specified in your Gruntfile.js under the task name yslow.
 
-###Options
+### Options
 - **thresholds** (object) - An object specifying the global thresholds to test against. These can be overridden by higher specificity against inside the files section below.
     - **weight** (number) - The maximum page weight allowed (kb).
     - **speed** (number) - The maximum load time of the page allowed (ms).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
